### PR TITLE
start to add keras support

### DIFF
--- a/examples/test_keras.py
+++ b/examples/test_keras.py
@@ -1,0 +1,77 @@
+from folktables import ACSDataSource
+from folktables import ACSIncome, generate_categories
+import keras
+import tensorflow as tf
+import numpy as np
+
+
+# data_source = ACSDataSource(survey_year='2018', horizon='1-Year', survey='person')
+# data = data_source.get_data(states=["AL"], download=True)
+
+# definition_df = data_source.get_definitions(download=True)
+# categories = generate_categories(features=ACSIncome.features, definition_df=definition_df)
+
+# df_feat, df_labels, _ = ACSIncome.df_to_pandas(data, categories=categories, dummies=True)
+# df_feat.head()
+
+# sens_cols = ['SEX_Female', 'SEX_Male']
+# feat = df_feat.drop(columns=sens_cols).to_numpy(dtype="float")
+# sens = df_feat[sens_cols].to_numpy(dtype="float")
+# label = df_labels.to_numpy(dtype="float")
+
+# np.save("feat", feat)
+# np.save("sens", sens)
+# np.save("label", label)
+
+feat = np.load("feat.npy")
+sens = np.load("sens.npy")
+label = np.load("label.npy")
+
+print(sens.mean(axis=0))
+
+
+from fairret.statistic import TruePositiveRate
+from fairret.loss import NormLoss
+
+statistic = TruePositiveRate(torch=False)
+norm_loss = NormLoss(statistic)
+
+h_layer_dim = 16
+lr = 1e-3
+batch_size = 1024
+
+
+keras.utils.set_random_seed(0)
+print(f"Shape of the 'normal' features tensor: {feat.shape}")
+print(f"Shape of the sensitive features tensor: {sens.shape}")
+print(f"Shape of the labels tensor: {label.shape}")
+
+h_layer_dim = 16
+lr = 1e-3
+batch_size = 1024
+
+def combined_loss(y_true, y_pred):
+    logit = y_pred
+    batch_label = y_true[:, 0:1]
+    batch_sens = y_true[:, 1:3]
+
+    loss = tf.reduce_mean(tf.square(logit - batch_label)) + norm_loss(logit, batch_sens, batch_label)
+
+    return loss
+
+model = keras.Sequential(
+    [
+        keras.layers.Dense(h_layer_dim, activation="relu"),
+        keras.layers.Dense(1),
+    ]
+)
+
+optimizer = keras.optimizers.Adam(learning_rate=lr)
+
+model.compile(
+    optimizer=optimizer,
+    loss=combined_loss,
+    run_eagerly=True
+)
+
+model.fit(x=feat, y=np.column_stack((label, sens)))

--- a/fairret/statistic/base.py
+++ b/fairret/statistic/base.py
@@ -27,3 +27,26 @@ class Statistic(abc.ABC, torch.nn.Module):
             torch.Tensor: Shape :math:`(S)`.
         """
         raise NotImplementedError
+
+    def __call__(self, pred: torch.Tensor, sens: torch.Tensor, *stat_args: Any, pred_as_logit=True, **stat_kwargs: Any
+                ) -> torch.Tensor:
+        """
+        Override __call__ method from torch.nn.Module. If self.torch we use the torch.nn.Module.__call__() otherwise
+        we only compute the forward pass (tensorflow case).
+
+        Args:
+            pred (torch.Tensor): Predictions of shape :math:`(N, 1)`, as we assume to be performing binary
+                classification or regression.
+            sens (torch.Tensor): Sensitive features of shape :math:`(N, S)` with `S` the number of sensitive features.
+            *stat_args: Any further arguments used to compute the statistic.
+            (bool): Whether the `pred` tensor should be interpreted as logits. Though most losses are
+                will simply take the sigmoid of `pred` if `pred_as_logit` is `True`, some losses benefit from improved
+                numerical stability if they handle the conversion themselves.
+            **stat_kwargs: Any keyword arguments used to compute the statistic.
+
+        Returns:
+            torch.Tensor: Shape :math:`(S)`.
+        """
+        if self.torch:
+            return super().__call__(pred, sens, stat_args, *pred_as_logit, **stat_kwargs)
+        return self.forward(pred, sens, *stat_args, **stat_kwargs)

--- a/fairret/utils.py
+++ b/fairret/utils.py
@@ -1,7 +1,19 @@
 import torch
+import tensorflow as tf
 
 
-def safe_div(num, denom, eps=1e-20):
+def safe_div_tf(num, denom, eps=1e-20):
+    if tf.math.reduce_any(tf.math.is_nan(num)) or tf.math.reduce_any(tf.math.is_nan(denom)):
+        raise ValueError("Cannot safely divide due to NaN values in numerator or denominator.")
+
+    zero_num_idx = tf.math.abs(num) < eps
+    zero_denom_idx = tf.math.abs(denom) < eps
+    if tf.math.reduce_any(zero_denom_idx) and tf.math.reduce_any(~zero_num_idx[zero_denom_idx]):
+        raise ZeroDivisionError(f"Division by zero denominator {denom} despite non-zero numerator ({num}).")
+
+    return tf.math.divide_no_nan(num, denom)
+
+def safe_div_torch(num, denom, eps=1e-20):
     if num.isnan().any() or denom.isnan().any():
         raise ValueError("Cannot safely divide due to NaN values in numerator or denominator.")
 
@@ -13,3 +25,9 @@ def safe_div(num, denom, eps=1e-20):
     res = torch.zeros_like(num)
     res[~zero_num_idx] = num[~zero_num_idx] / denom[~zero_num_idx]
     return res
+
+
+def safe_div(num, denom, eps=1e-20, torch=True):
+    if torch:
+        return safe_div_torch(num, denom, eps)
+    return safe_div_tf(num, denom, eps)


### PR DESCRIPTION
As discussed this week at EWAF24 I started to add keras support for the libary. For now this PR should just show how it would look and what changes are needed to add this support. I think it should be easy to add but it would need some if cases here and there.

For now one example works for a sequential keras model (see `test_keras.py`). It feels a bit like a "hack" since one has to override the `__call__` function of the torch.nn.Module. This also leads to some logging errors/warnings in keras. Maybe some kind of "conditionally inherits" of the `class Statistic(abc.ABC, torch.nn.Module):` would be cleaner. Also some conditional typing like `value: torch.Tensor | tf.Tensor` would be needed.

Looking forward for your feedback.